### PR TITLE
Update DoctrineWriter.php

### DIFF
--- a/src/DoctrineWriter.php
+++ b/src/DoctrineWriter.php
@@ -181,6 +181,8 @@ class DoctrineWriter implements Writer, Writer\FlushableWriter
         $this->updateObject($item, $object);
 
         $this->objectManager->persist($object);
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Without it chaining as in example on the website:

```use Port\Doctrine\DoctrineWriter;

$writer = new DoctrineWriter($objectManager, 'YourNamespace:Employee');
$writer
    ->prepare()
    ->writeItem(
        [
            'first' => 'James',
            'last'  => 'Bond'
        ]
    )
    ->finish();
```
gives

```
  [Symfony\Component\Debug\Exception\FatalThrowableError]  
  Call to a member function writeItem() on null     
```