### PR TITLE
Automatically set lookupFields based on the entities identifier fields

### DIFF
--- a/src/DoctrineWriter.php
+++ b/src/DoctrineWriter.php
@@ -99,6 +99,8 @@ class DoctrineWriter implements Writer, Writer\FlushableWriter
             } else {
                 $this->lookupFields = [$index];
             }
+        } else {
+            $this->lookupFields = $this->objectMetadata->getIdentifierFieldNames();
         }
 
         if (!method_exists($this->objectRepository, $lookupMethod)) {


### PR DESCRIPTION
This is an untested change and the PR is more meant to start a discussion on this since this is kind of a BC break.

Inside the class itself the following code uses the `lookupFields`:
```
            if (!empty($this->lookupFields)) {
                $lookupConditions = array();
                foreach ($this->lookupFields as $fieldName) {
                    $lookupConditions[$fieldName] = $item[$fieldName];
                }

                $object = call_user_func($this->lookupMethod, $lookupConditions);
            } else {
                $object = $this->objectRepository->find(current($item));
            }
```

The else case would now of course never be reached. Now `$index` defaults to `null` in the constructor. We could of course make it even more flexible by optionally also supporting a `boolean` to determine if to use the old approach or if to use the new approach added in this PR.

wdyt?