### PR TITLE
doctrine-reader: add querybuilder support

### DIFF
--- a/src/DoctrineReader.php
+++ b/src/DoctrineReader.php
@@ -50,7 +50,7 @@ class DoctrineReader implements CountableReader
         return $this;
     }
 
-    public function getQueryBuilder()
+    protected function getQueryBuilder()
     {
         if ($this->queryBuilder === null) {
             $this->queryBuilder = $this->objectManager->createQueryBuilder()


### PR DESCRIPTION
currently there was no extensibility possible, i.e to prevent whole table being dumped.