### PR TITLE
(Re-)Add missing return statement in DoctrineWriter

### DIFF
--- a/src/DoctrineWriter.php
+++ b/src/DoctrineWriter.php
@@ -159,6 +159,8 @@ class DoctrineWriter implements Writer, Writer\FlushableWriter
         if (true === $this->truncate) {
             $this->truncateTable();
         }
+
+        return $this;
     }
 
     /**

--- a/src/DoctrineWriter.php
+++ b/src/DoctrineWriter.php
@@ -4,7 +4,7 @@ namespace Port\Doctrine;
 
 use Port\Doctrine\Exception\UnsupportedDatabaseTypeException;
 use Port\Writer;
-use Doctrine\Common\Util\Inflector;
+use Doctrine\Common\Inflector\Inflector;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
@@ -191,7 +191,7 @@ class DoctrineWriter implements Writer, Writer\FlushableWriter
     public function flush()
     {
         $this->objectManager->flush();
-        $this->objectManager->clear($this->objectName);
+        $this->objectManager->clear();
     }
 
     /**

--- a/tests/DoctrineWriterTest.php
+++ b/tests/DoctrineWriterTest.php
@@ -278,8 +278,7 @@ class DoctrineWriterTest extends \PHPUnit_Framework_TestCase
         $em = $this->getEntityManager();
 
         $em->expects($this->once())
-            ->method('clear')
-            ->with($this->equalTo(self::TEST_ENTITY));
+            ->method('clear');
 
         $writer = new DoctrineWriter($em, 'Port:TestEntity');
         $writer->finish();


### PR DESCRIPTION
The prepare function in DoctrineWriter has lost the return statement, but it is still specified in PHPDoc. So if you create a preparedWriter with this function, it will be set to null.