### PR TITLE
Update dependencies - allow doctrine/common:3.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,14 @@
     "require": {
         "php": ">=5.6.0",
         "portphp/portphp": "^1.0.0",
-        "doctrine/common": "^2.2"
+        "doctrine/common": "^2.13 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.2",
         "ext-sqlite3": "*",
-        "doctrine/orm": "~2.4",
-        "doctrine/mongodb-odm": "^1.0"
+        "doctrine/orm": "~2.8",
+        "doctrine/mongodb-odm": "^2.0",
+        "doctrine/cache": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/src/DoctrineReader.php
+++ b/src/DoctrineReader.php
@@ -2,7 +2,7 @@
 
 namespace Port\Doctrine;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;

--- a/src/DoctrineWriter.php
+++ b/src/DoctrineWriter.php
@@ -2,12 +2,13 @@
 
 namespace Port\Doctrine;
 
+use Doctrine\Persistence\ObjectRepository;
 use Port\Doctrine\Exception\UnsupportedDatabaseTypeException;
 use Port\Writer;
-use Doctrine\Common\Util\Inflector;
+use Doctrine\Inflector\Inflector;
 use Doctrine\DBAL\Logging\SQLLogger;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
  * A bulk Doctrine writer

--- a/tests/DoctrineWriterTest.php
+++ b/tests/DoctrineWriterTest.php
@@ -49,7 +49,7 @@ class DoctrineWriterTest extends \PHPUnit_Framework_TestCase
     public function testUnsupportedDatabaseTypeException()
     {
         $this->expectException('Port\Doctrine\Exception\UnsupportedDatabaseTypeException');
-        $em = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')
+        $em = $this->getMockBuilder('Doctrine\Persistence\ObjectManager')
             ->getMock();
         new DoctrineWriter($em, 'Port:TestEntity');
     }


### PR DESCRIPTION
My take on updating dependencies. Tests (without MongoDB) pass locally. Will continue with testing on our project....

Travis is still configured to test against EOL PHP versions and more recent versions are missing. Maybe we should update that too. 